### PR TITLE
Código do facebook movido do head para o body

### DIFF
--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -10,7 +10,6 @@ html lang="#{I18n.locale}" xmlns:fb="http://ogp.me/ns/fb#"
     meta name="robots" content="index, follow"
     meta name="author" content="Engage"
     = yield :meta_tags
-    = render :partial => 'projects/facebook_sdk'
     = stylesheet_link_tag 'application', :media => 'screen, projection'
     /[if lt IE 9]
       = javascript_include_tag "http://html5shiv.googlecode.com/svn/trunk/html5.js"
@@ -22,6 +21,7 @@ html lang="#{I18n.locale}" xmlns:fb="http://ogp.me/ns/fb#"
     = render '/layouts/analytics'
 
   body[id="platform" data-namespace="#{namespace}" data-controller="#{controller_name}" data-action="#{action_name}" data-locale="#{I18n.locale}" data-user="#{current_user.to_json}"]
+    = render :partial => 'projects/facebook_sdk'
     = render partial: 'layouts/flash', locals: { flash: flash } unless flash.empty?
 
     = render 'layouts/header'


### PR DESCRIPTION
Conforme a documentação (https://developers.facebook.com/docs/javascript/quickstart/ em Basic Setup), o Facebook deveria estar sendo carregado logo após o inicio do body. Certo?